### PR TITLE
support parameter references in swagger spec

### DIFF
--- a/http_prompt/context/__init__.py
+++ b/http_prompt/context/__init__.py
@@ -39,6 +39,10 @@ class Context(object):
                         params = info.get('parameters')
                         if params:
                             for param in params:
+                                if param.get("$ref"):
+                                    for section in param.get("$ref").split('/'):
+                                        param = param.get(section) if not section == "#" else spec
+
                                 if param.get('in') != 'path':
                                     full_path = path_tokens + [param['name']]
                                     self.root.add_path(*full_path,


### PR DESCRIPTION
Swagger allows to reuse common parameters by referencing items of the top-level `parameters` section. The parameter section in `paths` then looks like

```
      parameters:
        - $ref: "#/parameters/max"
        - $ref: "#/parameters/offset"
```

An error is thrown at the moment in that case, because a `name` property is expected and references are not resolved.

This PR resolves references from the top-level parameters object if `$ref` is found.