### PR TITLE
Collects parameters directly below of the endpoint paths

### DIFF
--- a/http_prompt/context/__init__.py
+++ b/http_prompt/context/__init__.py
@@ -35,16 +35,17 @@ class Context(object):
                         path_tokens[-1] = path_tokens[-1] + '/'
                     self.root.add_path(*path_tokens)
                     endpoint = paths[path]
+                    params = []
                     for method, info in endpoint.items():
-                        if not isinstance(info, dict):
+                        if method == 'parameters':
+                            params.extend(info)
+                        else:
+                            params.extend(getattr(info, 'parameters', []))
+                    for param in params:
+                        if param.get('in') == 'path':
                             continue
-                        params = info.get('parameters')
-                        if params:
-                            for param in params:
-                                if param.get('in') != 'path':
-                                    full_path = path_tokens + [param['name']]
-                                    self.root.add_path(*full_path,
-                                                       node_type='file')
+                        full_path = path_tokens + [param['name']]
+                        self.root.add_path(*full_path, node_type='file')
         elif not self.url:
             self.url = 'http://localhost:8000'
 

--- a/http_prompt/context/__init__.py
+++ b/http_prompt/context/__init__.py
@@ -36,6 +36,8 @@ class Context(object):
                     self.root.add_path(*path_tokens)
                     endpoint = paths[path]
                     for method, info in endpoint.items():
+                        if not isinstance(info, dict):
+                            continue
                         params = info.get('parameters')
                         if params:
                             for param in params:


### PR DESCRIPTION
The endpoint paths can have the parameters to directly below.

An example:
https://github.com/apiaryio/swagger-zoo/blob/aa9118ac8db87594fb9ceb4e5c7ad0bb55a7a2f3/fixtures/examples/swagger/instagram.yaml#L215-L219
```yaml
paths:
  /users/{user-id}:
    parameters:
      - $ref: '#/parameters/user-id'
    get:
      ...
```