### PR TITLE
fix #166 passing arguments to httpie

### DIFF
--- a/http_prompt/execution.py
+++ b/http_prompt/execution.py
@@ -489,6 +489,11 @@ class ExecutionVisitor(NodeVisitor):
 
     def _call_httpie_main(self):
         context = self._final_context()
+
+        # XXX: httpie_main() expects args[0] to be program_name as in
+        # sys.argv, so we use this dirty hack to prevent it from taking
+        # some option name as program name thus misinterpreting other args.
+        program_name = "https" if context.url.startswith("https://") else "http"
         args = extract_args_for_httpie_main(context, self.method)
         env = Environment(stdout=self.output, stdin=sys.stdin,
                           is_windows=False)
@@ -503,7 +508,7 @@ class ExecutionVisitor(NodeVisitor):
         # interested in.
         sys.settrace(self._trace_get_response)
         try:
-            httpie_main(args, env=env)
+            httpie_main([program_name] + args, env=env)
         finally:
             sys.settrace(None)
 

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -58,7 +58,7 @@ class ExecutionTestCase(TempAppDirTestCase):
             patcher.stop()
 
     def assert_httpie_main_called_with(self, args):
-        self.assertEqual(self.httpie_main.call_args[0][0], args)
+        self.assertEqual(self.httpie_main.call_args[0][0][1:], args)
 
     def assert_stdout(self, expected_msg):
         # Append '\n' to simulate behavior of click.echo_via_pager(),


### PR DESCRIPTION
`httpie_main()` expects `args[0]` to be _program_name_ as in `sys.argv`, so I suggest this hack to prevent httpie from taking some option name as program name thus misinterpreting other arguments.