### PR TITLE
Use standard shlex.quote

### DIFF
--- a/http_prompt/context/transform.py
+++ b/http_prompt/context/transform.py
@@ -53,10 +53,8 @@ def _extract_httpie_request_items(context, quote=False):
         for k, value in sorted(item_dict.items()):
             if sep == ':=':
                 json_str = json.dumps(value,
-                                      sort_keys=True).replace("'", "\\'")
-                if isinstance(value, str) and quote:
-                    json_str = "'" + json_str + "'"
-                item = quote_func('%s:=%s' % (k, json_str))
+                                      sort_keys=True)
+                item = '%s:=%s' % (k, quote_func(json_str))
                 items.append(item)
             elif isinstance(value, (list, tuple)):
                 for v in value:

--- a/http_prompt/utils.py
+++ b/http_prompt/utils.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 
 import math
 import re
+import shlex
 
 from prompt_toolkit.shortcuts import create_output
 
@@ -10,10 +11,7 @@ RE_ANSI_ESCAPE = re.compile(r'\x1b[^m]*m')
 
 
 def smart_quote(s):
-    # TODO: Escape
-    if ' ' in s or r'\:' in s:
-        s = "'" + s + "'"
-    return s
+    return shlex.quote(s)
 
 
 def unquote(s):


### PR DESCRIPTION
Use standard `shelx.quote` to make `httpie` output ready for paste into command line as existing implementation produces incorrectly quoted results in cases like `--auth=username:m8J^a$P9#LdEc`.