### PR TITLE
Update test_interaction.py

### DIFF
--- a/tests/test_interaction.py
+++ b/tests/test_interaction.py
@@ -60,7 +60,7 @@ class TestInteraction(TempAppDirTestCase):
         bin_path = get_http_prompt_path()
         child = pexpect.spawn(bin_path, env=os.environ)
 
-        child.expect_exact('http://localhost:8000> ')
+        child.expect_exact('http://localhost:8000>')
 
         # Enter 'htpie', switch to command mode (ESC),
         # move two chars left (hh), and insert (i) a 't'


### PR DESCRIPTION
Don't fail at ANSI escape codes between '>' and ' ' (space) characters

when testing on macports test_interaction.py fail with this message:

````
:info:test self = <pexpect.expect.Expecter object at 0x10a8538b0>, err = TIMEOUT('Timeout exceeded.')
:info:test     def timeout(self, err=None):
:info:test         spawn = self.spawn
:info:test     
:info:test         spawn.before = spawn._before.getvalue()
:info:test         spawn.after = TIMEOUT
:info:test         index = self.searcher.timeout_index
:info:test         if index >= 0:
:info:test             spawn.match = TIMEOUT
:info:test             spawn.match_index = index
:info:test             return index
:info:test         else:
:info:test             spawn.match = None
:info:test             spawn.match_index = None
:info:test             msg = str(spawn)
:info:test             msg += '\nsearcher: %s' % self.searcher
:info:test             if err is not None:
:info:test                 msg = str(err) + '\n' + msg
:info:test     
:info:test             exc = TIMEOUT(msg)
:info:test             exc.__cause__ = None    # in Python 3.x we can use "raise exc from None"
:info:test >           raise exc
:info:test E           pexpect.exceptions.TIMEOUT: Timeout exceeded.
:info:test E           <pexpect.pty_spawn.spawn object at 0x10a853e50>
:info:test E           command: /opt/local/Library/Frameworks/Python.framework/Versions/3.8/bin/http-prompt
:info:test E           args: ['/opt/local/Library/Frameworks/Python.framework/Versions/3.8/bin/http-prompt']
:info:test E           buffer (last 100 chars): b'3C\x1b[?7h\x1b[0m\x1b[?12l\x1b[?25h'
:info:test E           before (last 100 chars): b'm\x1b[?7l\x1b[0m\x1b[J\x1b[0mhttp://localhost:8000>\x1b[0m\r\r\n\r\r\n\r\r\n\r\r\n\r\r\n\r\r\n\r\r\n\x1b[0m \x08\x1b[7A\x1b[23C\x1b[?7h\x1b[0m\x1b[?12l\x1b[?25h'
:info:test E           after: <class 'pexpect.exceptions.TIMEOUT'>
:info:test E           match: None
:info:test E           match_index: None
:info:test E           exitstatus: None
:info:test E           flag_eof: False
:info:test E           pid: 1217
:info:test E           child_fd: 20
:info:test E           closed: False
:info:test E           timeout: 30
:info:test E           delimiter: <class 'pexpect.exceptions.EOF'>
:info:test E           logfile: None
:info:test E           logfile_read: None
:info:test E           logfile_send: None
:info:test E           maxread: 2000
:info:test E           ignorecase: False
:info:test E           searchwindowsize: None
:info:test E           delaybeforesend: 0.05
:info:test E           delayafterclose: 0.1
:info:test E           delayafterterminate: 0.1
:info:test E           searcher: searcher_string:
:info:test E               0: b'http://localhost:8000> '
:info:test /opt/local/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/site-packages/pexpect/expect.py:144: TIMEOUT
````
