### PR TITLE
Add http-prompt to Homebrew package manager

### DIFF
--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -25,6 +25,10 @@ To upgrade HTTP Prompt, do::
 
     $ pip install -U http-prompt
 
+It's also possible to install it using Homebrew::
+
+    $ brew install http-prompt
+
 
 Quickstart
 ----------


### PR DESCRIPTION
I prefer using Homebrew over pip to install CLI tools like this.

So added http-prompt to Homebrew: homebrew/homebrew-core#93458

Just wanted you guys to know that it's now available there.

I also updated the documentation to reflect that.
